### PR TITLE
add PyOpenSSL package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ parts:
     source: https://github.com/Tautulli/Tautulli.git
     source-type: git
     source-branch: master
-    stage-packages: [python3, python3-setuptools]
+    stage-packages: [python3, python3-setuptools, python3-openssl]
     override-build: |
       snapcraftctl build
       sed -i "s|'CHECK_GITHUB': (int, 'General', 1),|'CHECK_GITHUB': (int, 'General', 0),|g" $SNAPCRAFT_PART_INSTALL/plexpy/config.py


### PR DESCRIPTION
Add python3-openssl to avoid 'WARNING :: MainThread : The pyOpenSSL module is missing. Install this module to enable HTTPS. HTTPS will be disabled' error when trying to enable self-signed SSL via Tautulli advanced options.